### PR TITLE
Invalid Parameter Fixed ;)

### DIFF
--- a/2/interfaces.md
+++ b/2/interfaces.md
@@ -54,7 +54,7 @@ interface Car:
     def payForPetrol(): payable
 
 @external
-def test(some_address: address):
+def test(car_address: address):
     Car(car_address).calculateDoubleSpeed()  # cannot change storage
     Car(car_address).getSpeed()  # cannot change storage, but reads itself
     Car(car_address).increaseSpeed()  # storage can be altered


### PR DESCRIPTION
```vyper
interface Car:
    def calculateDoubleSpeed() -> uint256: pure
    def getSpeed() -> uint256: view
    def increaseSpeed(): nonpayable
    def payForPetrol(): payable

# Invalid Parameter "some_address", It should be "car_address".
@external
def test(some_address: address):
    Car(car_address).calculateDoubleSpeed()  # cannot change storage
    Car(car_address).getSpeed()  # cannot change storage, but reads itself
    Car(car_address).increaseSpeed()  # storage can be altered
    Car(car_address).payForPetrol(value=100)  # storage can be altered, and value can be sent
```
;`)